### PR TITLE
add ignores for env*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *#*
 tests/test-indexes/*
 /doc/example-index/*
+env*/


### PR DESCRIPTION
Dumb pull request to ignore env*/ in the root so I can do "virtualenv env26"
